### PR TITLE
Add core library for credit-based API monetization

### DIFF
--- a/gringotts/__init__.py
+++ b/gringotts/__init__.py
@@ -1,0 +1,14 @@
+"""Gringotts core library for API monetization."""
+
+from .db import Base, SessionLocal, engine
+from . import models, crud, auth, decorators
+
+__all__ = [
+    "Base",
+    "SessionLocal",
+    "engine",
+    "models",
+    "crud",
+    "auth",
+    "decorators",
+]

--- a/gringotts/auth.py
+++ b/gringotts/auth.py
@@ -1,0 +1,26 @@
+import secrets
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def generate_api_key() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def get_api_key_hash(api_key: str) -> str:
+    return pwd_context.hash(api_key)
+
+
+def verify_api_key(api_key: str, hashed: str) -> bool:
+    return pwd_context.verify(api_key, hashed)
+
+
+def create_user_with_key(db: Session, username: str, credits: int = 0):
+    from . import crud  # lazy import to avoid circular
+
+    api_key = generate_api_key()
+    hash_ = get_api_key_hash(api_key)
+    user = crud.create_user(db, username=username, api_key_hash=hash_, credits=credits)
+    return user, api_key

--- a/gringotts/create_tables.py
+++ b/gringotts/create_tables.py
@@ -1,45 +1,11 @@
-import sqlite3
+from .db import Base, engine
+from . import models
 
-# Connect to the database (creates a new database if it doesn't exist)
-conn = sqlite3.connect('database.db')
 
-# Create a cursor object to execute SQL statements
-cursor = conn.cursor()
+def create_tables():
+    Base.metadata.create_all(bind=engine)
 
-# Create the User table
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS User (
-        Username TEXT PRIMARY KEY,
-        Password TEXT,
-        Email TEXT,
-        APIKey TEXT UNIQUE,
-        TotalRemainingCredits INTEGER
-    )
-''')
 
-# Create the API Calls table
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS APICalls (
-        APIKey TEXT,
-        Date TEXT,
-        Call TEXT,
-        Cost INTEGER,
-        FOREIGN KEY (APIKey) REFERENCES User (APIKey)
-    )
-''')
-
-# Create the Transactions table
-cursor.execute('''
-    CREATE TABLE IF NOT EXISTS Transactions (
-        Username TEXT,
-        Cost REAL,
-        Date TEXT,
-        FOREIGN KEY (Username) REFERENCES User (Username)
-    )
-''')
-
-# Commit the changes and close the connection
-conn.commit()
-conn.close()
-
-print("Tables created successfully!")
+if __name__ == "__main__":
+    create_tables()
+    print("Tables created successfully!")

--- a/gringotts/crud.py
+++ b/gringotts/crud.py
@@ -1,31 +1,34 @@
-import sqlite3
+from sqlalchemy.orm import Session
 
-def create_user(username, password, email, api_key, total_credits):
-    conn = sqlite3.connect('database.db')
-    cursor = conn.cursor()
-    cursor.execute('INSERT INTO User (Username, Password, Email, APIKey, TotalRemainingCredits) VALUES (?, ?, ?, ?, ?)',
-                   (username, password, email, api_key, total_credits))
-    conn.commit()
-    conn.close()
+from . import models, auth
 
-def read_user(username):
-    conn = sqlite3.connect('database.db')
-    cursor = conn.cursor()
-    cursor.execute('SELECT * FROM User WHERE Username = ?', (username,))
-    user = cursor.fetchone()
-    conn.close()
+
+def create_user(db: Session, username: str, api_key_hash: str, credits: int = 0) -> models.User:
+    user = models.User(username=username, api_key_hash=api_key_hash, credits=credits)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
     return user
 
-def update_user_credits(username, credits):
-    conn = sqlite3.connect('database.db')
-    cursor = conn.cursor()
-    cursor.execute('UPDATE User SET TotalRemainingCredits = ? WHERE Username = ?', (credits, username))
-    conn.commit()
-    conn.close()
 
-def delete_user(username):
-    conn = sqlite3.connect('database.db')
-    cursor = conn.cursor()
-    cursor.execute('DELETE FROM User WHERE Username = ?', (username,))
-    conn.commit()
-    conn.close()
+def get_user_by_api_key(db: Session, api_key: str) -> models.User | None:
+    for user in db.query(models.User).all():
+        if auth.verify_api_key(api_key, user.api_key_hash):
+            return user
+    return None
+
+
+def update_user_credits(db: Session, user: models.User, delta: int) -> models.User:
+    user.credits += delta
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def log_api_call(db: Session, user: models.User, endpoint: str, cost: int) -> models.APICall:
+    call = models.APICall(user_id=user.id, endpoint=endpoint, cost=cost)
+    db.add(call)
+    db.commit()
+    db.refresh(call)
+    return call

--- a/gringotts/db.py
+++ b/gringotts/db.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = "sqlite:///./gringotts.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/gringotts/decorators.py
+++ b/gringotts/decorators.py
@@ -1,0 +1,83 @@
+import inspect
+from functools import wraps
+
+from fastapi import HTTPException, Request
+
+from .db import SessionLocal
+from . import crud
+
+
+class InvalidAPIKey(HTTPException):
+    def __init__(self) -> None:
+        super().__init__(status_code=401, detail="Invalid API key")
+
+
+class InsufficientCredits(HTTPException):
+    def __init__(self) -> None:
+        super().__init__(status_code=402, detail="Insufficient credits")
+
+
+def _extract_request(args, kwargs):
+    request = kwargs.get("request")
+    if request is None:
+        for arg in args:
+            if isinstance(arg, Request):
+                request = arg
+                break
+    return request
+
+
+def requires_credits(cost: int = 1):
+    """Decorator to enforce that a request has enough credits."""
+
+    def decorator(func):
+        if inspect.iscoroutinefunction(func):
+            async def async_wrapper(*args, **kwargs):
+                request = _extract_request(args, kwargs)
+                if request is None:
+                    raise RuntimeError("Request object not found")
+
+                api_key = request.headers.get("X-API-Key")
+                if not api_key:
+                    raise InvalidAPIKey()
+
+                db = SessionLocal()
+                try:
+                    user = crud.get_user_by_api_key(db, api_key)
+                    if not user:
+                        raise InvalidAPIKey()
+                    if user.credits < cost:
+                        raise InsufficientCredits()
+                    crud.update_user_credits(db, user, -cost)
+                    crud.log_api_call(db, user, request.url.path, cost)
+                finally:
+                    db.close()
+                return await func(*args, **kwargs)
+
+            return wraps(func)(async_wrapper)
+        else:
+            def sync_wrapper(*args, **kwargs):
+                request = _extract_request(args, kwargs)
+                if request is None:
+                    raise RuntimeError("Request object not found")
+
+                api_key = request.headers.get("X-API-Key")
+                if not api_key:
+                    raise InvalidAPIKey()
+
+                db = SessionLocal()
+                try:
+                    user = crud.get_user_by_api_key(db, api_key)
+                    if not user:
+                        raise InvalidAPIKey()
+                    if user.credits < cost:
+                        raise InsufficientCredits()
+                    crud.update_user_credits(db, user, -cost)
+                    crud.log_api_call(db, user, getattr(request, "path", ""), cost)
+                finally:
+                    db.close()
+                return func(*args, **kwargs)
+
+            return wraps(func)(sync_wrapper)
+
+    return decorator

--- a/gringotts/main.py
+++ b/gringotts/main.py
@@ -1,35 +1,25 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Request
 from pydantic import BaseModel
+
+from .decorators import requires_credits
+from . import create_tables
+
+# Ensure tables exist
+create_tables.create_tables()
 
 app = FastAPI()
 
-# Define request payload model
+
 class PredictionRequest(BaseModel):
     input_string: str
-    api_key: str
 
-# Define response payload model
+
 class PredictionResponse(BaseModel):
     output_string: str
 
-# API endpoint for prediction
+
 @app.post("/predict", response_model=PredictionResponse)
-async def predict(request: PredictionRequest):
-    # Perform authentication and authorization here
-    # Check if the API key is valid and has access rights
-
-    # Mock prediction logic
-    output_string = f"Predicted: {request.input_string}"
-
-    # Return the prediction result
+@requires_credits(cost=1)
+async def predict(request: Request, payload: PredictionRequest):
+    output_string = f"Predicted: {payload.input_string}"
     return PredictionResponse(output_string=output_string)
-
-# Handle invalid input payload
-@app.exception_handler(HTTPException)
-async def validation_exception_handler(request, exc):
-    return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
-
-# Handle general exceptions
-@app.exception_handler(Exception)
-async def generic_exception_handler(request, exc):
-    return JSONResponse(status_code=500, content={"message": "Internal server error"})

--- a/gringotts/models.py
+++ b/gringotts/models.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+
+from .db import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    api_key_hash = Column(String, unique=True, nullable=False)
+    credits = Column(Integer, default=0)
+
+    calls = relationship("APICall", back_populates="user")
+
+
+class APICall(Base):
+    __tablename__ = "api_calls"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    endpoint = Column(String, nullable=False)
+    cost = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="calls")

--- a/gringotts/requirements.txt
+++ b/gringotts/requirements.txt
@@ -1,1 +1,3 @@
 fastapi
+sqlalchemy
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy models and session helpers
- add Passlib-based API key generation and credit decorator for FastAPI
- wire sample FastAPI endpoint to enforce credits

## Testing
- `pip install -r gringotts/requirements.txt`
- `python -m py_compile gringotts/*.py`
- `python - <<'PY'
from fastapi.testclient import TestClient
from gringotts.main import app
from gringotts.db import SessionLocal
from gringotts.auth import create_user_with_key
from gringotts import crud

with SessionLocal() as db:
    user, api_key = create_user_with_key(db, 'alice', credits=5)

client = TestClient(app)
resp = client.post('/predict', headers={'X-API-Key': api_key}, json={'input_string':'hello'})
print('status', resp.status_code, 'body', resp.json())

with SessionLocal() as db:
    user = crud.get_user_by_api_key(db, api_key)
    print('remaining credits', user.credits)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b5c6cbfce8832f979ffcf5d306c613