### PR TITLE
Add CRUD example and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ Users can:
 4. Monitor their API credits remaining and the requests they made and how much each cost
 5. Get response from an API if API Key has credits remaining. Otherwise error 'too few credits.'
 
+### Quick Example
+
+```python
+from crud import create_user, read_user
+
+# Create a user and look it up
+create_user("alice", "password", "alice@example.com", "key123", 100)
+print(read_user("alice"))
+```
+
+Run `python gringotts/example.py` for a more complete demonstration.
+
 Automatically create when user is created
 Add Credits
 

--- a/gringotts/crud.py
+++ b/gringotts/crud.py
@@ -1,31 +1,41 @@
 import sqlite3
 
-def create_user(username, password, email, api_key, total_credits):
-    conn = sqlite3.connect('database.db')
+
+def create_user(username, password, email, api_key, total_credits, db_path="database.db"):
+    """Insert a user record into the database."""
+    conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    cursor.execute('INSERT INTO User (Username, Password, Email, APIKey, TotalRemainingCredits) VALUES (?, ?, ?, ?, ?)',
-                   (username, password, email, api_key, total_credits))
+    cursor.execute(
+        "INSERT INTO User (Username, Password, Email, APIKey, TotalRemainingCredits) VALUES (?, ?, ?, ?, ?)",
+        (username, password, email, api_key, total_credits),
+    )
     conn.commit()
     conn.close()
 
-def read_user(username):
-    conn = sqlite3.connect('database.db')
+
+def read_user(username, db_path="database.db"):
+    """Return a user row for the given username."""
+    conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    cursor.execute('SELECT * FROM User WHERE Username = ?', (username,))
+    cursor.execute("SELECT * FROM User WHERE Username = ?", (username,))
     user = cursor.fetchone()
     conn.close()
     return user
 
-def update_user_credits(username, credits):
-    conn = sqlite3.connect('database.db')
+
+def update_user_credits(username, credits, db_path="database.db"):
+    """Update the remaining credits for a user."""
+    conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    cursor.execute('UPDATE User SET TotalRemainingCredits = ? WHERE Username = ?', (credits, username))
+    cursor.execute("UPDATE User SET TotalRemainingCredits = ? WHERE Username = ?", (credits, username))
     conn.commit()
     conn.close()
 
-def delete_user(username):
-    conn = sqlite3.connect('database.db')
+
+def delete_user(username, db_path="database.db"):
+    """Delete a user by username."""
+    conn = sqlite3.connect(db_path)
     cursor = conn.cursor()
-    cursor.execute('DELETE FROM User WHERE Username = ?', (username,))
+    cursor.execute("DELETE FROM User WHERE Username = ?", (username,))
     conn.commit()
     conn.close()

--- a/gringotts/example.py
+++ b/gringotts/example.py
@@ -1,0 +1,39 @@
+"""Quick example demonstrating CRUD helpers."""
+
+import sqlite3
+
+from crud import create_user, delete_user, read_user, update_user_credits
+
+
+def main() -> None:
+    db_path = "example.db"
+
+    # Ensure the User table exists.
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS User (
+            Username TEXT PRIMARY KEY,
+            Password TEXT,
+            Email TEXT,
+            APIKey TEXT UNIQUE,
+            TotalRemainingCredits INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    # Demonstrate the helper functions.
+    create_user("alice", "password", "alice@example.com", "key123", 100, db_path=db_path)
+    print("After creation:", read_user("alice", db_path=db_path))
+    update_user_credits("alice", 150, db_path=db_path)
+    print("After credit update:", read_user("alice", db_path=db_path))
+    delete_user("alice", db_path=db_path)
+    print("After deletion:", read_user("alice", db_path=db_path))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,43 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+
+# Make the crud module importable
+sys.path.append(str(Path(__file__).resolve().parents[1] / "gringotts"))
+
+from crud import create_user, delete_user, read_user, update_user_credits
+
+
+def setup_db(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE User (
+            Username TEXT PRIMARY KEY,
+            Password TEXT,
+            Email TEXT,
+            APIKey TEXT UNIQUE,
+            TotalRemainingCredits INTEGER
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_crud_cycle(tmp_path):
+    db_path = tmp_path / "test.db"
+    setup_db(db_path)
+
+    create_user("bob", "pw", "bob@example.com", "key", 50, db_path=db_path)
+    user = read_user("bob", db_path=db_path)
+    assert user == ("bob", "pw", "bob@example.com", "key", 50)
+
+    update_user_credits("bob", 75, db_path=db_path)
+    assert read_user("bob", db_path=db_path)[4] == 75
+
+    delete_user("bob", db_path=db_path)
+    assert read_user("bob", db_path=db_path) is None
+


### PR DESCRIPTION
## Summary
- allow CRUD helpers to target a custom SQLite database
- document and script a simple CRUD usage example
- add unit test covering CRUD cycle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b60a8ef8a4832f80bc510312997fde