### PR TITLE
Add example and tests for credit-based API access

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,30 @@ Users can:
 4. Monitor their API credits remaining and the requests they made and how much each cost
 5. Get response from an API if API Key has credits remaining. Otherwise error 'too few credits.'
 
-Automatically create when user is created
-Add Credits
+### Quick Example
 
+1. Start the API:
 
+```bash
+uvicorn gringotts.main:app
+```
 
-Call API Endpoint: 
-Updates transactions table
-Updates user table (total remaining credits)
-	
-How?
-We log who made the call using the API Key
-Checks if there are remaining credits. If yes, then calls the API and updates the tables. Otherwise 
+2. Create a user and API key:
 
+```python
+from gringotts import auth, db
+db_session = db.SessionLocal()
+user, api_key = auth.create_user_with_key(db_session, "alice", credits=5)
+print(api_key)
+```
 
+3. Call the protected endpoint:
 
+```bash
+curl -X POST "http://localhost:8000/predict" \
+  -H "Content-Type: application/json" \
+  -H "X-API-Key: $API_KEY" \
+  -d '{"input_string": "hello"}'
+```
 
 ### Authors

--- a/gringotts/requirements.txt
+++ b/gringotts/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 sqlalchemy
 passlib[bcrypt]
+httpx

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,77 @@
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from gringotts import auth, crud, models, db, decorators
+
+
+@pytest.fixture
+def db_session(monkeypatch):
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db.Base.metadata.create_all(bind=engine)
+
+    monkeypatch.setattr(db, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(decorators, "SessionLocal", TestingSessionLocal)
+
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def create_app():
+    app = FastAPI()
+
+    @app.get("/hello")
+    @decorators.requires_credits(cost=2)
+    async def hello(request: Request):
+        return {"msg": "world"}
+
+    return app
+
+
+def test_requires_credits_deducts_and_logs(db_session):
+    user, key = auth.create_user_with_key(db_session, "alice", credits=5)
+
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/hello", headers={"X-API-Key": key})
+    assert res.status_code == 200
+    assert res.json() == {"msg": "world"}
+
+    db_session.refresh(user)
+    assert user.credits == 3
+
+    calls = db_session.query(models.APICall).all()
+    assert len(calls) == 1
+    assert calls[0].endpoint == "/hello"
+    assert calls[0].cost == 2
+
+
+def test_requires_credits_invalid_key(db_session):
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/hello", headers={"X-API-Key": "bad"})
+    assert res.status_code == 401
+
+
+def test_requires_credits_insufficient_credits(db_session):
+    user, key = auth.create_user_with_key(db_session, "bob", credits=1)
+
+    app = create_app()
+    client = TestClient(app)
+
+    res = client.get("/hello", headers={"X-API-Key": key})
+    assert res.status_code == 402


### PR DESCRIPTION
## Summary
- Document how to run the API, create a user, and call a protected endpoint
- Include httpx dependency for FastAPI's test client
- Add tests validating credit deduction, logging, and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b60bc86a70832f97b9e81fae47ad58