### PR TITLE
Fix atomic credit deduction to prevent double spending

### DIFF
--- a/gringotts/decorators.py
+++ b/gringotts/decorators.py
@@ -46,9 +46,8 @@ def requires_credits(cost: int = 1):
                     user = crud.get_user_by_api_key(db, api_key)
                     if not user:
                         raise InvalidAPIKey()
-                    if user.credits < cost:
+                    if not crud.deduct_user_credits(db, user, cost):
                         raise InsufficientCredits()
-                    crud.update_user_credits(db, user, -cost)
                     crud.log_api_call(db, user, request.url.path, cost)
                 finally:
                     db.close()
@@ -70,9 +69,8 @@ def requires_credits(cost: int = 1):
                     user = crud.get_user_by_api_key(db, api_key)
                     if not user:
                         raise InvalidAPIKey()
-                    if user.credits < cost:
+                    if not crud.deduct_user_credits(db, user, cost):
                         raise InsufficientCredits()
-                    crud.update_user_credits(db, user, -cost)
                     crud.log_api_call(db, user, getattr(request, "path", ""), cost)
                 finally:
                     db.close()


### PR DESCRIPTION
## Summary
- ensure credit deduction and validation occur atomically via new `deduct_user_credits`
- update credit enforcement decorator to use atomic deduction

## Testing
- `pip install -r gringotts/requirements.txt`
- `python -m py_compile gringotts/*.py`
- `python - <<'PY'
from fastapi.testclient import TestClient
from gringotts.main import app
from gringotts.db import SessionLocal
from gringotts.auth import create_user_with_key
from gringotts import crud

with SessionLocal() as db:
    user, api_key = create_user_with_key(db, 'alice', credits=5)

client = TestClient(app)
resp = client.post('/predict', headers={'X-API-Key': api_key}, json={'input_string':'hello'})
print('status', resp.status_code, 'body', resp.json())

with SessionLocal() as db:
    user = crud.get_user_by_api_key(db, api_key)
    print('remaining credits', user.credits)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b60c83ff40832fb88a3070c437ffc4